### PR TITLE
refactor: Implement CSS-based line clearing animation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ leptos-use = "0.15.7"
 rand = "0.9.0"
 reactive_stores = "0.1.8"
 wasm-bindgen = "0.2.100"
-web-sys = { version = "0.3.77", features = ["Window", "Document"] }
+web-sys = { version = "0.3.77", features = ["Window", "Document", "Performance"] }

--- a/tailwind.css
+++ b/tailwind.css
@@ -2,3 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 @plugin "daisyui";
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.line-clearing-animation {
+  animation: fadeOut 0.5s linear forwards;
+}


### PR DESCRIPTION
Replaces the previous tick-based line clearing animation with a smoother, CSS-driven fade-out effect. This addresses your feedback regarding animation quality and perceived lag.

Key changes:
- Added a CSS class `line-clearing-animation` for a 500ms fade-out effect.
- Modified `Tetris` struct:
    - Removed `animation_step`.
    - Added `animation_start_time: Option<f64>` to track animation start.
- `clear_lines` method now:
    - Sets `lines_being_cleared` and `animation_start_time` (using `performance.now()` on wasm32).
    - Defers actual block removal and shifting.
- `TetrisGame` component rendering:
    - Applies the `line-clearing-animation` CSS class to cells in lines being cleared.
    - Old flashing logic removed from `render_view`.
- `Tetris::tick` method now:
    - Checks if 500ms have passed since `animation_start_time` (on wasm32).
    - If so, finalizes line removal, block shifting, and resets animation state.
    - Calls `clear_lines` again for potential chain reactions.
- Game logic (piece falling, player input except pause) remains paused during the 500ms animation.
- Updated unit test `test_line_clearing_animation` to align with the new time-based logic and non-wasm32 test behavior.

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

使用基于 CSS 的淡出效果来实现消除行的动画，并重构游戏逻辑，以使用时间戳而不是滴答计数来跟踪动画计时。

新功能：
- 引入一个 500 毫秒的 CSS "fadeOut" 动画，并通过一个新的 `.line-clearing-animation` 类来应用它

增强功能：
- 将 `animation_step` 计数器替换为 `animation_start_time`，并使用 `performance.now()` 来确定动画完成时间
- 在渲染逻辑中应用 CSS 动画类，并移除手动闪烁代码
- 重构 ghost 和当前俄罗斯方块的渲染，以将视觉清除效果推迟到 CSS

构建：
- 将 `Performance` 功能添加到 `web-sys` 依赖项中，以实现基于时间戳的动画

测试：
- 更新消除行的动画测试，以期望 `animation_start_time` 初始化，并在非 wasm 环境中模拟动画完成

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use a CSS-based fade-out effect for line-clearing animation and refactor the game logic to track animation timing with timestamps instead of tick counts.

New Features:
- Introduce a 500ms CSS "fadeOut" animation and apply it via a new `.line-clearing-animation` class

Enhancements:
- Replace the `animation_step` counter with `animation_start_time` and use `performance.now()` to determine animation completion
- Apply the CSS animation class in the rendering logic and remove manual flashing code
- Refactor ghost and current tetromino rendering to defer visual clearing effects to CSS

Build:
- Add the `Performance` feature to the `web-sys` dependency for timestamp-based animation

Tests:
- Update the line-clearing animation test to expect `animation_start_time` initialization and simulate animation completion in non-wasm environments

</details>